### PR TITLE
Add css classes for the color theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,49 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
+/* ===== Global Styles ===== */
 body {
+  background-color: #F0EBE3; /* Light Sand */
+  color: #37474F; /* Slate Gray */
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+  padding: 0;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+/* ===== Custom Text Colors ===== */
+.text-forest-green {
+  color: #2E7D32 !important;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+.text-slate-gray {
+  color: #37474F !important;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+/* ===== Custom Backgrounds ===== */
+.bg-white-custom {
+  background-color: #ffffff !important;
+}
+
+.bg-light-sand {
+  background-color: #F0EBE3 !important;
+}
+
+/* ===== Custom Button ===== */
+.btn-terra {
+  background-color: #E07A5F !important;
+  color: white !important;
+  border: none;
+}
+
+.btn-terra:hover {
+  background-color: #d2694f !important;
+}
+
+/* ===== Form Styling ===== */
+input, textarea {
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
+input:focus, textarea:focus {
+  border-color: #81D4FA; /* Sky Blue */
+  box-shadow: 0 0 0 0.2rem rgba(129, 212, 250, 0.25);
+  outline: none;
 }


### PR DESCRIPTION
I know this wasn't one of the issues, but in the process of making a page, I ended up creating this.
I wasn't sure which color theme we had decided on, so I used the nature-inspired one.
When you make a page, you can copy-paste this css to ChatGPT and tell it to use these classes as well as bootstrap for the styling.