### PR TITLE
change trip ids to uuid, change event to activity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react-dom": "^19.1.0",
         "react-responsive-carousel": "^3.2.23",
         "react-router-dom": "^7.6.2",
-        "react-time-picker": "^7.0.0"
+        "react-time-picker": "^7.0.0",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -3326,6 +3327,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-dom": "^19.1.0",
     "react-responsive-carousel": "^3.2.23",
     "react-router-dom": "^7.6.2",
-    "react-time-picker": "^7.0.0"
+    "react-time-picker": "^7.0.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/components/trips/TripForm.jsx
+++ b/src/components/trips/TripForm.jsx
@@ -10,8 +10,8 @@ export default function TripForm({ trip, onSave, onCancel }) {
   const [startDate, setStartDate] = useState(trip.startDate || '');
   const [endDate, setEndDate] = useState(trip.endDate || '');
   const [itinerary, setItinerary] = useState(trip.itinerary || []);
-  const [newEventTime, setNewEventTime] = useState({});
-  const [newEventName, setNewEventName] = useState({});
+  const [newActivityTime, setNewActivityTime] = useState({});
+  const [newActivityName, setNewActivityName] = useState({});
   const [error, setError] = useState('');
 
   // Convert MM/DD/YYYY → yyyy-MM-dd (for date input)
@@ -41,7 +41,7 @@ export default function TripForm({ trip, onSave, onCancel }) {
           const prevMap = Object.fromEntries(prev.map(day => [day.date, day]));
           return days.map(date => {
             const dateStr = format(date, 'MM/dd/yyyy');
-            return prevMap[dateStr] || { date: dateStr, events: [] };
+            return prevMap[dateStr] || { date: dateStr, activities: [] };
           });
         });
       } else {
@@ -52,9 +52,9 @@ export default function TripForm({ trip, onSave, onCancel }) {
     }
   }, [startDate, endDate]);
 
-  const handleAddEvent = (date) => {
-    const time = newEventTime[date];
-    const name = newEventName[date];
+  const handleAddActivity = (date) => {
+    const time = newActivityTime[date];
+    const name = newActivityName[date];
     if (!time || !name) return;
 
     const formattedTime = formatTime12Hour(time);
@@ -63,7 +63,7 @@ export default function TripForm({ trip, onSave, onCancel }) {
       prev.map(day => {
         if (day.date !== date) return day;
 
-        const updatedEvents = [...day.events, { time: formattedTime, name }].sort((a, b) => {
+        const updatedActivities = [...day.activities, { time: formattedTime, name }].sort((a, b) => {
           const parseTime = (str) => {
             const [t, mod] = str.split(' ');
             let [h, m] = t.split(':');
@@ -74,12 +74,12 @@ export default function TripForm({ trip, onSave, onCancel }) {
           return parseTime(a.time).localeCompare(parseTime(b.time));
         });
 
-        return { ...day, events: updatedEvents };
+        return { ...day, activities: updatedActivities };
       })
     );
 
-    setNewEventTime({ ...newEventTime, [date]: '' });
-    setNewEventName({ ...newEventName, [date]: '' });
+    setNewActivityTime({ ...newActivityTime, [date]: '' });
+    setNewActivityName({ ...newActivityName, [date]: '' });
   };
 
   const formatTime12Hour = (timeStr) => {
@@ -90,11 +90,11 @@ export default function TripForm({ trip, onSave, onCancel }) {
     return `${displayHour}:${minute} ${suffix}`;
   };
 
-  const handleRemoveEvent = (date, index) => {
+  const handleRemoveActivity = (date, index) => {
     setItinerary(prev =>
       prev.map(day =>
         day.date === date
-          ? { ...day, events: day.events.filter((_, i) => i !== index) }
+          ? { ...day, activities: day.activities.filter((_, i) => i !== index) }
           : day
       )
     );
@@ -108,7 +108,7 @@ export default function TripForm({ trip, onSave, onCancel }) {
     }
     const itineraryToSave = itinerary.map(day => ({
       date: day.date,
-      events: [...day.events]
+      activities: [...day.activities]
     }));
     onSave({
       ...trip,
@@ -163,13 +163,13 @@ export default function TripForm({ trip, onSave, onCancel }) {
             <div key={i} className="border rounded p-3 mb-3">
               <strong>{day.date}</strong>
               <ul className="list-unstyled">
-                {day.events.map((event, j) => (
+                {day.activities.map((activity, j) => (
                   <li key={j}>
-                    {event.time} — {event.name}
+                    {activity.time} — {activity.name}
                     <button
                       type="button"
                       className="btn btn-sm btn-outline-danger ms-2"
-                      onClick={() => handleRemoveEvent(day.date, j)}
+                      onClick={() => handleRemoveActivity(day.date, j)}
                     >
                       Remove
                     </button>
@@ -181,22 +181,22 @@ export default function TripForm({ trip, onSave, onCancel }) {
                   disableClock={true}
                   clearIcon={null}
                   format="h:mm a"
-                  value={newEventTime[day.date] || ''}
-                  onChange={(val) => setNewEventTime({ ...newEventTime, [day.date]: val })}
+                  value={newActivityTime[day.date] || ''}
+                  onChange={(val) => setNewActivityTime({ ...newActivityTime, [day.date]: val })}
                 />
                 <input
                   type="text"
                   className="form-control"
-                  placeholder="Event Description"
-                  value={newEventName[day.date] || ''}
-                  onChange={(e) => setNewEventName({ ...newEventName, [day.date]: e.target.value })}
+                  placeholder="Activity Description"
+                  value={newActivityName[day.date] || ''}
+                  onChange={(e) => setNewActivityName({ ...newActivityName, [day.date]: e.target.value })}
                 />
                 <button
                   type="button"
                   className="btn btn-sm btn-outline-primary"
-                  onClick={() => handleAddEvent(day.date)}
+                  onClick={() => handleAddActivity(day.date)}
                 >
-                  + Add Event
+                  + Add Activity
                 </button>
               </div>
             </div>

--- a/src/pages/Trips.jsx
+++ b/src/pages/Trips.jsx
@@ -3,25 +3,27 @@ import { useState } from 'react'
 import TripForm from '../components/trips/TripForm'
 import TripList from '../components/trips/TripList'
 import { format, eachDayOfInterval, parse } from 'date-fns'
+import { v4 as uuidv4 } from 'uuid'
+
 
 export default function Trips() {
   const [trips, setTrips] = useState([
     {
-      id: 1,
+      id: uuidv4(),
       destination: 'Venice',
       startDate: '07/01/2025',
       endDate:   '07/02/2025',
       itinerary: [
         {
           date: '07/01/2025',
-          events: [
+          activities: [
             { time: '10:00 AM', name: 'Gondola Ride' },
             { time: '2:00 PM', name: 'Piazza San Marco' }
           ]
         },
         {
           date: '07/02/2025',
-          events: [
+          activities: [
             { time: '9:00 AM', name: 'Doge’s Palace' },
             { time: '12:00 PM', name: 'Murano Glass Tour' }
           ]
@@ -29,21 +31,21 @@ export default function Trips() {
       ]
     },
     {
-      id: 2,
+      id: uuidv4(),
       destination: 'Reykjavík',
       startDate: '07/10/2025',
       endDate:   '07/11/2025',
       itinerary: [
         {
           date: '07/10/2025',
-          events: [
+          activities: [
             { time: '11:00 AM', name: 'Blue Lagoon' },
             { time: '3:00 PM',  name: 'Sun Voyager Sculpture' }
           ]
         },
         {
           date: '07/11/2025',
-          events: [
+          activities: [
             { time: '8:00 AM',  name: 'Golden Circle Tour' },
             { time: '1:00 PM',  name: 'Perlan Museum' }
           ]
@@ -83,18 +85,18 @@ export default function Trips() {
 
     const itinerary = days.map(date => {
       const dateStr = format(date, 'MM/dd/yyyy')
-      // find any existing events for that day
-      const dayEvents =
-        trip.itinerary.find(d => d.date === dateStr)?.events || []
+      // find any existing activities for that day
+      const dayActivities =
+        trip.itinerary.find(d => d.date === dateStr)?.activities || []
 
-      // sort events by time ascending
-      const sortedEvents = [...dayEvents].sort((a, b) => {
+      // sort activities by time ascending
+      const sortedActivities = [...dayActivities].sort((a, b) => {
         const a24 = convertTo24Hour(a.time)
         const b24 = convertTo24Hour(b.time)
         return a24.localeCompare(b24)
       })
 
-      return { date: dateStr, events: sortedEvents }
+      return { date: dateStr, activities: sortedActivities }
     })
 
     const finalTrip = { ...trip, itinerary }
@@ -104,7 +106,7 @@ export default function Trips() {
       setTrips(trips.map(t => (t.id === trip.id ? finalTrip : t)))
     } else {
       // new trip
-      finalTrip.id = Date.now()
+      finalTrip.id = uuidv4()
       setTrips([...trips, finalTrip])
     }
 
@@ -178,9 +180,9 @@ export default function Trips() {
               className="mb-4 p-4 bg-white-custom rounded shadow-sm"
             >
               <h5 className="text-forest-green">{dayPlan.date}</h5>
-              {dayPlan.events.length > 0 && (
+              {dayPlan.activities.length > 0 && (
                 <ul className="list-unstyled">
-                  {dayPlan.events.map((ev, i) => (
+                  {dayPlan.activities.map((ev, i) => (
                     <li key={i} className="d-flex mb-1">
                       <div
                         className="me-3 text-end"


### PR DESCRIPTION
I installed and imported uuid to make unique ids for each trip instead of just using `Date.now()`
Also, I felt like "activity" would be better word choice than "event", because "event" tends to have other usage in JavaScript.

These changes are not actually necessary for the functionality of our site, but I like it better this way, and I feel it may make things clearer for us.