### PR TITLE
Delete the .vite/deps folder

### DIFF
--- a/frontend/.vite/deps/_metadata.json
+++ b/frontend/.vite/deps/_metadata.json
@@ -1,8 +1,0 @@
-{
-  "hash": "d432fc4b",
-  "configHash": "29cfe5d6",
-  "lockfileHash": "e3b0c442",
-  "browserHash": "f36673a5",
-  "optimized": {},
-  "chunks": {}
-}

--- a/frontend/.vite/deps/package.json
+++ b/frontend/.vite/deps/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}


### PR DESCRIPTION
fixes #50 

This folder was created when I moved the react-app files to a subfolder.
I think it was causing problems.
The app worked on my local when I deleted this, and ChatGPT says it is safe to delete and deleting it is actually a common troubleshooting step.