### PR TITLE
updated import to work with file location

### DIFF
--- a/frontend/src/pages/Trips.test.jsx
+++ b/frontend/src/pages/Trips.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import Trips from '../../pages/Trips'
+import Trips from './Trips'
 import '@testing-library/jest-dom'
 import { vi } from 'vitest'
 


### PR DESCRIPTION
I should have done this before, but didn't notice the problem until I merged that pr.
The Trips page import was written to work in this file's previous location so it didn't work now that it has been moved.
This time, I tested on my local after I fixed it, before making a pr, something I overlooked last time.

fixes #124 