### PR TITLE
added s3 bucket secret requirement in cicd

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,4 +58,11 @@ jobs:
         run: sam build
 
       - name: Deploy SAM application
-        run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --stack-name TripTrekStack --capabilities CAPABILITY_IAM --region ${{ secrets.AWS_REGION }}
+        run: |
+          sam deploy \
+            --no-confirm-changeset \
+            --no-fail-on-empty-changeset \
+            --stack-name TripTrekStack \
+            --capabilities CAPABILITY_IAM \
+            --s3-bucket ${{ secrets.SAM_S3_BUCKET }} \
+            --region ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
closes #128 

without it, it will try to use s3 bucket name defined in samconfig.toml but it will fail since s3 buckets need to be unique globally.
once this is merged, you will need to create s3 bucket in your aws and in github secrets
save your secret under name of SAM_S3_BUCKET